### PR TITLE
Check if order shipping method is not null

### DIFF
--- a/Plugin/Sales/OrderRepositoryPlugin.php
+++ b/Plugin/Sales/OrderRepositoryPlugin.php
@@ -95,6 +95,10 @@ class OrderRepositoryPlugin
         $shippingMethod = $order->getShippingMethod(true);
         $carrierCode = $shippingMethod->getData('carrier_code');
 
+        if (!$shippingMethod) {
+            return $order;
+        }
+
         if ($carrierCode !== Paazlshipping::CODE) {
             return $order;
         }


### PR DESCRIPTION
Fixes the following error:
Uncaught Error: Call to a member function getData() on null