### PR TITLE
Make sure the total price is of type double

### DIFF
--- a/Model/Checkout/WidgetConfigProvider.php
+++ b/Model/Checkout/WidgetConfigProvider.php
@@ -170,7 +170,7 @@ class WidgetConfigProvider implements ConfigProviderInterface
             ],
             "shipmentParameters"         => [
                 "totalWeight"   => $this->getTotalWeight(),
-                "totalPrice"    => $this->formatPrice($this->getQuote()->getSubtotal()),
+                "totalPrice"    => $this->getQuote()->getSubtotal(),
                 "numberOfGoods" => $this->getProductsCount(),
                 "goods"         => $goods
             ],


### PR DESCRIPTION
Causes a error with the Paazl api call.

![shipping-options-response](https://user-images.githubusercontent.com/6631170/81676006-be0be800-944f-11ea-99d8-2b9949e0508e.png)
![shipping-options-headers](https://user-images.githubusercontent.com/6631170/81676021-c106d880-944f-11ea-978d-f6c858d403c3.png)

This code is also used in https://github.com/Paazl/magento2-checkout-widget/blob/master/Model/Order/WidgetConfigProvider.php#L112. Not sure if this also needs fixing.