### PR TITLE
Fix: API does not accept strings as length/width/height.

### DIFF
--- a/Model/Checkout/WidgetConfigProvider.php
+++ b/Model/Checkout/WidgetConfigProvider.php
@@ -140,9 +140,9 @@ class WidgetConfigProvider implements ConfigProviderInterface
             ];
             if ($useDimensions) {
                 $product = $this->productRepository->getById($item->getProduct()->getId());
-                $goodsItem["length"] = (int) $product->getData($lengthAttribute);
-                $goodsItem["width"] = (int) $product->getData($widthAttribute);
-                $goodsItem["height"] = (int) $product->getData($heightAttribute);
+                $goodsItem["length"] = (float) $product->getData($lengthAttribute);
+                $goodsItem["width"] = (float) $product->getData($widthAttribute);
+                $goodsItem["height"] = (float) $product->getData($heightAttribute);
             }
 
             if (($itemNumberOfProcessingDays = $this->getProductNumberOfProcessingDays($item))


### PR DESCRIPTION
A webshop of our customer has these attributes filled with strings. I've added explicit cast so floats are always returned.