### PR TITLE
Fix total price shipment parameter

### DIFF
--- a/Model/Checkout/WidgetConfigProvider.php
+++ b/Model/Checkout/WidgetConfigProvider.php
@@ -187,7 +187,7 @@ class WidgetConfigProvider implements ConfigProviderInterface
             ],
             "shipmentParameters"         => [
                 "totalWeight"   => (float)$this->getTotalWeight($goods),
-                "totalPrice"    => (float)$this->getQuote()->getSubtotalWithDiscount(),
+                "totalPrice"    => 0.0000,
                 "numberOfGoods" => (int)$this->getProductsCount(),
                 "goods"         => $goods
             ],

--- a/Model/Checkout/WidgetConfigProvider.php
+++ b/Model/Checkout/WidgetConfigProvider.php
@@ -203,16 +203,16 @@ class WidgetConfigProvider implements ConfigProviderInterface
 
         switch ($this->scopeConfig->getTotalPrice()) {
             case "grand_total":
-                $totalPriceValue = (float) $this->getQuote()->getShippingAddress()->getGrandTotal();
+                $totalPriceValue = (float) $shippingAddress->getGrandTotal();
                 break;
             case "subtotal_excl_discount":
-                $totalPriceValue = (float) $this->getQuote()->getShippingAddress()->getSubtotalInclTax();
+                $totalPriceValue = (float) $shippingAddress->getSubtotalInclTax();
                 break;
             case "subtotal_incl_discount":
             default: // default from config.xml = "subtotal_incl_discount"
                 $totalPriceValue = (
-                    (float) $this->getQuote()->getShippingAddress()->getSubtotalInclTax() +
-                    (float) $this->getQuote()->getShippingAddress()->getDiscountAmount()
+                    (float) $shippingAddress->getSubtotalInclTax() +
+                    (float) $shippingAddress->getDiscountAmount()
                 );
                 break;
         }

--- a/Model/Checkout/WidgetConfigProvider.php
+++ b/Model/Checkout/WidgetConfigProvider.php
@@ -219,7 +219,7 @@ class WidgetConfigProvider implements ConfigProviderInterface
     public function getQuote()
     {
         if (!$this->quote) {
-            return $this->checkoutHelper->getQuote();
+            $this->quote = $this->checkoutHelper->getQuote();
         }
 
         return $this->quote;

--- a/Model/Checkout/WidgetConfigProvider.php
+++ b/Model/Checkout/WidgetConfigProvider.php
@@ -13,7 +13,6 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Item\AbstractItem;
-use Magento\Sales\Model\OrderFactory;
 use Paazl\CheckoutWidget\Helper\General as GeneralHelper;
 use Paazl\CheckoutWidget\Model\Config;
 use Paazl\CheckoutWidget\Model\Handler\Item as ItemHandler;
@@ -41,11 +40,6 @@ class WidgetConfigProvider implements ConfigProviderInterface
      * @var Data
      */
     private $checkoutHelper;
-
-    /**
-     * @var OrderFactory
-     */
-    private $order;
 
     /**
      * @var GeneralHelper
@@ -82,7 +76,6 @@ class WidgetConfigProvider implements ConfigProviderInterface
      *
      * @param Config            $scopeConfig
      * @param Data              $checkoutHelper
-     * @param OrderFactory      $order
      * @param GeneralHelper     $generalHelper
      * @param ItemHandler       $itemHandler
      * @param TokenRetriever    $tokenRetriever
@@ -92,7 +85,6 @@ class WidgetConfigProvider implements ConfigProviderInterface
     public function __construct(
         Config $scopeConfig,
         Data $checkoutHelper,
-        OrderFactory $order,
         GeneralHelper $generalHelper,
         ItemHandler $itemHandler,
         TokenRetriever $tokenRetriever,
@@ -101,7 +93,6 @@ class WidgetConfigProvider implements ConfigProviderInterface
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->checkoutHelper = $checkoutHelper;
-        $this->order = $order;
         $this->generalHelper = $generalHelper;
         $this->itemHandler = $itemHandler;
         $this->tokenRetriever = $tokenRetriever;

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "paazl/magento2-checkout-widget",
   "description": "Paazl checkoutWidget for Magento 2",
   "type": "magento2-module",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "keywords": [
     "Paazl",
     "Magento 2",


### PR DESCRIPTION
Fixed multiple issues from the issues backlog if I'm right:

1) You made use of the quote->Totals instead of the shippingAddress Totals which is a best practice and contains the values including vat which is what you expect.

2) Small addition to declare this->quote if it's not declared for some reason, could not find a case how this could happen, but still.

3) Removed redundant orderFactory variable

Would be nice to merge this in the master branch and tag a new version for this. I think a lot of clients are waiting for this to be merged. 
