### PR TITLE
Fixes wrong config class member name.

### DIFF
--- a/Model/Api/Builder/Order.php
+++ b/Model/Api/Builder/Order.php
@@ -388,7 +388,7 @@ class Order
         $dimensionArray = [];
         $product = $item->getProduct();
 
-        switch ($this->scopeConfig->getDimensionsMetric()) {
+        switch ($this->config->getDimensionsMetric()) {
             case DimensionsMetric::METRIC_MM:
                 $k = 0.1;
                 break;


### PR DESCRIPTION
Version 1.16.0 released last week introduced a bug. Found by our client:

```
[2024-03-04T15:35:03.576889+00:00] Magento2.INFO: exception: Error sending order data to Paazl: Warning: Undefined property: Paazl\CheckoutWidget\Model\Api\Builder\Order::$scopeConfig in vendor/paazl/magento2-checkout-widget/Model/Api/Builder/Order.php on line 391 [] []
```

This PR fixes this.