### PR TITLE
Made some templates with inline javascript CSP compliant. While keepi…

### DIFF
--- a/view/adminhtml/templates/order/create/paazl-js.phtml
+++ b/view/adminhtml/templates/order/create/paazl-js.phtml
@@ -4,13 +4,13 @@
  * See COPYING.txt for license details.
  */
 
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Magento\Backend\Block\Template;
 
-// @codingStandardsIgnoreFile
+/** @var Template $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
-/* @var $block Magento\Backend\Block\Template */
-?>
-
-<script type="text/javascript">
+$scriptString = "
     require([
         'jquery',
         'Magento_Sales/order/create/scripts',
@@ -40,4 +40,11 @@
             }
         );
     });
-</script>
+";
+
+?>
+<?php if (class_exists(SecureHtmlRenderer::class)): ?>
+    <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
+<?php else: ?>
+    <?= /* @noEscape */ sprintf('<script type="text/javascript">%s</script>', $scriptString) ?>
+<?php endif; ?>

--- a/view/adminhtml/templates/order/create/shipping/method/paazl/widget/config.phtml
+++ b/view/adminhtml/templates/order/create/shipping/method/paazl/widget/config.phtml
@@ -4,16 +4,24 @@
  * See COPYING.txt for license details.
  */
 
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Paazl\CheckoutWidget\Block\Adminhtml\Order\Create\Shipping\Method\Paazl\Widget\Config as WidgetConfig;
 
-// @codingStandardsIgnoreFile
+/** @var WidgetConfig $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 
-/* @var $block Paazl\CheckoutWidget\Block\Adminhtml\Order\Create\Shipping\Method\Paazl\Widget\Config */
-?>
-<script>
+$scriptString = "
     require(
-        ["Magento_Sales/order/create/form"],
+        ['Magento_Sales/order/create/form'],
         function () {
-            Object.assign(order, <?= /* @escapeNotVerified */ $block->getSerializedWidgetConfig() ?>);
+            Object.assign(order, {$block->getSerializedWidgetConfig()});
         }
     );
-</script>
+";
+
+?>
+<?php if (class_exists(SecureHtmlRenderer::class)): ?>
+    <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
+<?php else: ?>
+    <?= /* @noEscape */ sprintf('<script>%s</script>', $scriptString) ?>
+<?php endif; ?>

--- a/view/base/templates/checkout/widget.phtml
+++ b/view/base/templates/checkout/widget.phtml
@@ -4,21 +4,30 @@
  * See COPYING.txt for license details.
  */
 
-// @codingStandardsIgnoreFile
+use Magento\Framework\View\Helper\SecureHtmlRenderer;
+use Paazl\CheckoutWidget\Block\Checkout\Widget as CheckoutWidgetBlock;
 
-/** @var Paazl\CheckoutWidget\Block\Checkout\Widget $block */
+/** @var CheckoutWidgetBlock $block */
+/** @var SecureHtmlRenderer $secureRenderer */
 ?>
-<?php if ($block->getApiBaseUrl()) : ?>
-<script type="text/javascript">
-    window.PAAZL_CHECKOUT_WIDGET_API_URL = '<?= /* @escapeNotVerified */ $block->getApiBaseUrl(); ?>';
-    window.PAAZL_CHECKOUT_WIDGET_LOCAL_RESOURCE_URL = '<?= /* @escapeNotVerified */ $block->getLocalResourceUrl(); ?>';
-</script>
+<?php
+    $scriptString = '';
+
+    if ($block->getApiBaseUrl()) {
+        $scriptString .= sprintf("window.PAAZL_CHECKOUT_WIDGET_API_URL = '%s';\n", $block->escapeJs($block->getApiBaseUrl()));
+        $scriptString .= sprintf("window.PAAZL_CHECKOUT_WIDGET_LOCAL_RESOURCE_URL = '%s';\n", $block->escapeJs($block->getLocalResourceUrl()));
+    }
+
+    if ($block->useLocal()) {
+        $scriptString .= sprintf("window.PAAZL_CHECKOUT_WIDGET_RESOURCE_URL = '%s';\n", $block->escapeJs($block->getLocalResourceUrl()));
+    }
+?>
+<?php if (class_exists(SecureHtmlRenderer::class)): ?>
+    <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
+<?php else: ?>
+    <?= /* @noEscape */ sprintf('<script type="text/javascript">%s</script>', $scriptString) ?>
 <?php endif; ?>
-<?php if ($block->useLocal()) : ?>
-    <script type="text/javascript">
-        window.PAAZL_CHECKOUT_WIDGET_RESOURCE_URL = '<?= /* @escapeNotVerified */ $block->getLocalResourceUrl(); ?>';
-    </script>
-<?php endif; ?>
+
 <?php if ($block->getCustomCss() != '') : ?>
 <style>:root {<?= /* @escapeNotVerified */ $block->getCustomCss() ?>}</style>
 <?php endif; ?>


### PR DESCRIPTION
…ng it backwards compatible with older Magento versions.

Partially fixes #122 
On recent Magento versions with a strict CSP policy (which is the default) on checkout and in backoffice when creating orders, some inline javascript refuses to execute if it doesn't has a `nonce` assigned to it. This PR introduces that.

I only tackled the template files that I encountered myself on a certain shop (both on frontend and backoffice while creating an order).
There are probably more inline scripts that will need to be tackled. I'll leave those up to you to deal with.

Your `composer.json` file indicates you still support PHP 7.4 and [your recent releases](https://github.com/Paazl/magento2-checkout-widget/releases/tag/1.20.0) claim you still support Magento 2.3.x, so I needed to get a bit creative because:
- The `SecureHtmlRenderer` class was only introduced in Magento 2.4.0, so if we want to be backwards compatible with Magento 2.3.x, we need to check if it exists first before attempting to use it.
- The convention is to use heredoc syntax to wrap the entire script into a php variable before outputting it, but there is a known bug in Magento 2.3.x which causes heredoc syntax to get screwed up by the html minifier ([fix in 2.4.0](https://github.com/magento/magento2/commit/41c3f6f4338326ee6efcf04a96555de9a0c3c436)), so I chose not to use heredoc syntax.

These 2 things make the code incredibly ugly and hard to read, so if you guys have better ideas, feel free to. Easiest would be to drop support for Magento 2.3.x, then we would be able to significantly improve the code readability.

Please test this carefully, I hope I didn't make mistakes, but you never know...