### PR TITLE
Only execute 'curl_close' function when using PHP < 8.0, it has no effect in 8.0 or higher and has even been deprecated in PHP 8.5

### DIFF
--- a/Model/Api/CurlExtra.php
+++ b/Model/Api/CurlExtra.php
@@ -105,7 +105,10 @@ class CurlExtra extends Curl
             // phpcs:ignore Magento2.Functions.DiscouragedFunction
             $this->doError(curl_error($this->_ch));
         }
-        // phpcs:ignore Magento2.Functions.DiscouragedFunction
-        curl_close($this->_ch);
+
+        if (PHP_VERSION_ID < 80000) {
+            // phpcs:ignore Magento2.Functions.DiscouragedFunction
+            curl_close($this->_ch);
+        }
     }
 }


### PR DESCRIPTION
See:
- https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.curl
- https://www.php.net/manual/en/function.curl-close.php


If you guys would decide to drop support for PHP 7.4 from the `composer.json` file, we could just remove these 2 lines instead of wrapping them in this if condition.