### PR TITLE
ADD isEnabled checks around plugin calls

### DIFF
--- a/Plugin/Checkout/ShippingInformationManagementPlugin.php
+++ b/Plugin/Checkout/ShippingInformationManagementPlugin.php
@@ -24,6 +24,7 @@ use Paazl\CheckoutWidget\Model\Carrier\Paazlshipping;
 use Paazl\CheckoutWidget\Model\Api\ApiException;
 use Paazl\CheckoutWidget\Model\Api\Field\DeliveryType;
 use Paazl\CheckoutWidget\Model\Quote\Totals\AppendShippingMethods;
+use Paazl\CheckoutWidget\Model\Config;
 
 /**
  * Class ShippingInformationManagementPlugin
@@ -68,6 +69,11 @@ class ShippingInformationManagementPlugin
     private $appendShippingMethods;
 
     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
      * ShippingInformationManagementPlugin constructor.
      *
      * @param PaazlApiFactory                   $paazlApiFactory
@@ -85,7 +91,8 @@ class ShippingInformationManagementPlugin
         CheckoutInfoToQuote $checkoutInfoToQuote,
         ShipmentEstimationInterface $shipmentEstimation,
         ArrayManager $arrayManager,
-        AppendShippingMethods $appendShippingMethods
+        AppendShippingMethods $appendShippingMethods,
+        Config $config
     ) {
         $this->paazlApiFactory = $paazlApiFactory;
         $this->referenceBuilder = $referenceBuilder;
@@ -94,6 +101,7 @@ class ShippingInformationManagementPlugin
         $this->shipmentEstimation = $shipmentEstimation;
         $this->arrayManager = $arrayManager;
         $this->appendShippingMethods = $appendShippingMethods;
+        $this->config = $config;
     }
 
     /**
@@ -173,7 +181,9 @@ class ShippingInformationManagementPlugin
         PaymentDetailsInterface $paymentDetails,
         $cartId
     ) {
-        $this->appendShippingMethods->append($paymentDetails->getTotals(), $cartId);
+        if ($this->config->isEnabled()) {
+            $this->appendShippingMethods->append($paymentDetails->getTotals(), $cartId);
+        }
 
         return $paymentDetails;
     }

--- a/Plugin/Quote/CartTotalRepositoryPlugin.php
+++ b/Plugin/Quote/CartTotalRepositoryPlugin.php
@@ -36,7 +36,7 @@ class CartTotalRepositoryPlugin
         Config $config
     ) {
         $this->appendShippingMethods = $appendShippingMethods;
-        $this->config                = $config
+        $this->config = $config;
     }
 
     /**

--- a/Plugin/Quote/CartTotalRepositoryPlugin.php
+++ b/Plugin/Quote/CartTotalRepositoryPlugin.php
@@ -12,9 +12,15 @@ use Magento\Framework\Exception\StateException;
 use Magento\Quote\Api\CartTotalRepositoryInterface;
 use Magento\Quote\Api\Data\TotalsInterface;
 use Paazl\CheckoutWidget\Model\Quote\Totals\AppendShippingMethods;
+use Paazl\CheckoutWidget\Model\Config;
 
 class CartTotalRepositoryPlugin
 {
+    /**
+     * @var Config
+     */
+    private $config;
+
     /**
      * @var AppendShippingMethods
      */
@@ -26,9 +32,11 @@ class CartTotalRepositoryPlugin
      * @param AppendShippingMethods $appendShippingMethods
      */
     public function __construct(
-        AppendShippingMethods $appendShippingMethods
+        AppendShippingMethods $appendShippingMethods,
+        Config $config
     ) {
         $this->appendShippingMethods = $appendShippingMethods;
+        $this->config                = $config
     }
 
     /**
@@ -44,8 +52,10 @@ class CartTotalRepositoryPlugin
         TotalsInterface $totals,
         $cartId
     ) {
-        $this->appendShippingMethods->append($totals, $cartId);
-
+        if ($this->config->isEnabled()) {
+            $this->appendShippingMethods->append($totals, $cartId);
+        }
+        
         return $totals;
     }
 }


### PR DESCRIPTION
Currently Plugin/Quote/CartTotalRepositoryPlugin.php is causing problems for me while the plugin is disabled.

After debugging it seems that this plugin is called for some reason because of a graphql call somewhere or another module from somewhere.

However because this is called, an exception `throw new StateException(__('The shipping address is missing. Set the address and try again.'));` From `\Magento\Quote\Model\ShippingMethodManagement::getList`

And this breaks my cart entirely. 

I'm using a graphql endpoint for this and the plugin is registered on the graphql/di.xml scope. 

I don't know if this works standalone perfectly fine, but perhaps this conflicts with modules currently in my setup.

After adding the `isEnabled()` check my cart is functioning again.

